### PR TITLE
Fix TLSConfig configuration

### DIFF
--- a/endpoint/httpws.go
+++ b/endpoint/httpws.go
@@ -107,11 +107,10 @@ func (e *HTTPWSendPoint) Init(listener chan transports.Message) error {
 	log.Infof("creating API service")
 
 	// Create a HTTP Proxy service
-	pxy, err := proxy(e.config.ListenHost, e.config.ListenPort, e.config.TLSdomain, e.config.TLSdirCert)
+	pxy, err := proxy(e.config.ListenHost, e.config.ListenPort, e.config.TLSconfig, e.config.TLSdomain, e.config.TLSdirCert)
 	if err != nil {
 		return err
 	}
-	pxy.TLSConfig = e.config.TLSconfig
 
 	// Create a HTTP+Websocket transport and attach the proxy
 	var ts transports.Transport
@@ -153,12 +152,13 @@ func (e *HTTPWSendPoint) Init(listener chan transports.Message) error {
 
 // proxy creates a new service for routing HTTP connections using go-chi server
 // if tlsDomain is specified, it will use letsencrypt to fetch a valid TLS certificate
-func proxy(host string, port int32, tlsDomain, tlsDir string) (*mhttp.Proxy, error) {
+func proxy(host string, port int32, tlsConfig *tls.Config, tlsDomain, tlsDir string) (*mhttp.Proxy, error) {
 	pxy := mhttp.NewProxy()
 	pxy.Conn.TLSdomain = tlsDomain
 	pxy.Conn.TLScertDir = tlsDir
 	pxy.Conn.Address = host
 	pxy.Conn.Port = port
+	pxy.TLSConfig = tlsConfig
 	log.Infof("creating proxy service, listening on %s:%d", host, port)
 	if pxy.Conn.TLSdomain != "" {
 		log.Infof("configuring proxy with TLS certificate for domain %s", tlsDomain)

--- a/transports/mhttp/proxy.go
+++ b/transports/mhttp/proxy.go
@@ -115,6 +115,7 @@ func (p *Proxy) Init() error {
 		s.WriteTimeout = 15 * time.Second
 		s.IdleTimeout = 30 * time.Second
 		s.ReadHeaderTimeout = 3 * time.Second
+		s.TLSConfig = p.TLSConfig
 		s.Handler = p.Server
 		if err := http2.ConfigureServer(s, nil); err != nil {
 			return err
@@ -140,7 +141,6 @@ func (p *Proxy) Init() error {
 			IdleTimeout:       60 * time.Second,
 			ReadHeaderTimeout: 3 * time.Second,
 			Handler:           p.Server,
-			TLSConfig:         p.TLSConfig,
 		}
 		if err := http2.ConfigureServer(s, nil); err != nil {
 			return err


### PR DESCRIPTION
This PR modifies how TLSConfig is loaded into the proxy. It must be done before Init is called (ServeTLS is called inside it) but it was assigned after running it.